### PR TITLE
Set the backing field for get-only properties

### DIFF
--- a/src/ReflectionMagic/Property.cs
+++ b/src/ReflectionMagic/Property.cs
@@ -31,7 +31,21 @@ namespace ReflectionMagic
 
         void IProperty.SetValue(object obj, object value, object[] index)
         {
-            _propertyInfo.SetValue(obj, value, index);
+            if (_propertyInfo.CanWrite)
+            {
+                _propertyInfo.SetValue(obj, value, index);
+            }
+            else
+            {
+                var backingFieldName = $"<{_propertyInfo.Name}>k__BackingField";
+                var type = obj.GetType();
+                var backingField = type.GetTypeInfo().GetField(backingFieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+                if (backingField == null)
+                {
+                    throw new MissingMemberException($"The property {type}.{_propertyInfo.Name} does not have a setter nor a backing field ({backingFieldName}).");
+                }
+                backingField.SetValue(obj, value);
+            }
         }
     }
 

--- a/test/LibraryWithPrivateMembers/MiscTestClasses.cs
+++ b/test/LibraryWithPrivateMembers/MiscTestClasses.cs
@@ -134,4 +134,11 @@ namespace LibraryWithPrivateMembers
         public string _field;
         public string Property { get; set; }
     }
+
+    public class Baz
+    {
+        public int PublicGetOnlyInteger { get; }
+        internal int InternalGetOnlyInteger { get; }
+        private int PrivateGetOnlyInteger { get; }
+    }
 }

--- a/test/ReflectionMagicTests/UnitTest.cs
+++ b/test/ReflectionMagicTests/UnitTest.cs
@@ -305,5 +305,32 @@ namespace ReflectionMagicTests
             Assert.Equal("test", fooBar._field);
             Assert.Equal("test", fooBar.Property);
         }
+
+        [Fact]
+        public void TestSettingPublicGetOnlyProperty()
+        {
+            var baz = new Baz();
+            baz.AsDynamic().PublicGetOnlyInteger = 42;
+
+            Assert.Equal(42, baz.PublicGetOnlyInteger);
+        }
+
+        [Fact]
+        public void TestSettingInternalGetOnlyProperty()
+        {
+            var baz = new Baz();
+            baz.AsDynamic().InternalGetOnlyInteger = 42;
+
+            Assert.Equal(42, baz.GetType().GetProperty("InternalGetOnlyInteger", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(baz));
+        }
+
+        [Fact]
+        public void TestSettingPrivateGetOnlyProperty()
+        {
+            var baz = new Baz();
+            baz.AsDynamic().PrivateGetOnlyInteger = 42;
+
+            Assert.Equal(42, baz.GetType().GetProperty("PrivateGetOnlyInteger", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(baz));
+        }
     }
 }


### PR DESCRIPTION
Before this commit `System.ArgumentException` was thrown with this message:
> Property set method not found.

Fixes #33